### PR TITLE
switch Option to notdeprecated one in imports

### DIFF
--- a/ecs.php.dist
+++ b/ecs.php.dist
@@ -8,7 +8,7 @@ use SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
-use Symplify\EasyCodingStandard\Configuration\Option;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 return static function (ContainerConfigurator $containerConfigurator): void {

--- a/packages/configuration/src/Option.php
+++ b/packages/configuration/src/Option.php
@@ -8,7 +8,7 @@ use Symplify\EasyCodingStandard\ValueObject\Option as NewOption;
 
 /**
  * @deprecated
- * Use \Symplify\EasyCodingStandard\ValueObject\Option insead
+ * Use \Symplify\EasyCodingStandard\ValueObject\Option instead
  */
 final class Option extends NewOption
 {


### PR DESCRIPTION
The file `ecs.php.dist` encourages developers to use an outdated `Option` class:

* `Symplify\EasyCodingStandard\Configuration\Option` is flagged as `@deprecated`
* it should be replaces with `Symplify\EasyCodingStandard\ValueObject\Option`
