### PR TITLE
Allow PrettyVersion 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.3",
         "composer/xdebug-handler": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.17.3",
-        "jean85/pretty-package-versions": "^1.5",
+        "jean85/pretty-package-versions": "^1.5 || ^2.0.1",
         "nette/utils": "^3.0",
         "nette/robot-loader": "^3.2",
         "ocramius/package-versions": "^1.4",


### PR DESCRIPTION
This simple bump allows for the 2.0 version of this lib, which leverages Composer 2 APIs and drops any sub dependency.

There are basically no BC; for more details, see the [the changelog](https://github.com/Jean85/pretty-package-versions/blob/2.x/CHANGELOG.md).