### PR TITLE
chore: update symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "6.1.*",
+        "symfony/dependency-injection": "^6.2",
         "symfony/finder": "^6.2",
         "symplify/autowire-array-parameter": "^11.1",
         "symplify/coding-standard": "^11.1.32",


### PR DESCRIPTION
Hi!

`symfony/dependency-injection` was probably intentionally kept on `6.1`, but I couldn't find the reason why. Was there a bug introduced in a specific `6.2.x` version?

Since the other Symfony deps are set to `^6.2` as well, is it possible to do the same for the DI component? I cannot require the latest version of this package at the moment, because I'm on `6.2` with all symfony components.

I can also do `^6.1|^6.2` to keep the impact to a minimum, let me know which you prefer.